### PR TITLE
Migrate tool.uv.dev-dependencies to dependency-groups.dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/kitsuyui/python-tally-token"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest",
     "pytest-cov",
     "poethepoet",


### PR DESCRIPTION
To comply with PEP 735 https://packaging.python.org/en/latest/specifications/dependency-groups/
UV supports PEP 735 after v0.4.27 https://github.com/astral-sh/uv/releases/tag/0.4.27
