### PR TITLE
Tighten Ruff lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,36 @@ ignore_missing_imports = false
 
 [tool.ruff]
 line-length = 79
+
+[tool.ruff.lint]
+select = [
+    "A",
+    "ANN",
+    "ARG",
+    "B",
+    "C4",
+    "C90",
+    "COM",
+    "E",
+    "F",
+    "I",
+    "PERF",
+    "PLE",
+    "PTH",
+    "RET",
+    "RUF",
+    "S",
+    "SIM",
+    "SLOT",
+    "UP",
+    "W",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    "ANN",
+    "D",
+    "S603",
+    "S101",
+    "S607",
+]

--- a/tally_token/__init__.py
+++ b/tally_token/__init__.py
@@ -14,7 +14,7 @@ from ._version import __version__
 
 
 def split_text(
-    clear_text: str, into: int = 2, *, encoding: str = "utf-8"
+    clear_text: str, into: int = 2, *, encoding: str = "utf-8",
 ) -> list[bytes]:
     """Split a text into multiple tokens.
 
@@ -43,7 +43,7 @@ def split_io(
     output_sizes = len(outfiles)
     for buf in iter(lambda: infile.read(bufsize), b""):
         token_bytes = split_bytes_into(buf, output_sizes)
-        for token, outfile in zip(token_bytes, outfiles):
+        for token, outfile in zip(token_bytes, outfiles, strict=False):
             outfile.write(token)
 
     # flush all the files
@@ -131,11 +131,11 @@ def _generate_random_token(size: int) -> bytes:
 
 
 __all__ = [
-    "split_text",
-    "split_io",
-    "split_bytes_into",
-    "merge_text",
-    "merge_io",
-    "merge_bytes_into",
     "__version__",
+    "merge_bytes_into",
+    "merge_io",
+    "merge_text",
+    "split_bytes_into",
+    "split_io",
+    "split_text",
 ]

--- a/tally_token/__main__.py
+++ b/tally_token/__main__.py
@@ -2,27 +2,34 @@ from __future__ import annotations
 
 import argparse
 from contextlib import ExitStack
+from pathlib import Path
 
 from tally_token import merge_io, split_io
 
 
 def split_main(
-    *, source_path: str, dest_paths: str, bufsize: int = 1024
+    *, source_path: str, dest_paths: list[str], bufsize: int = 1024,
 ) -> None:
     # ensure closing all the files even if an exception is raised
     with ExitStack() as stack:
-        infile = stack.enter_context(open(source_path, "rb"))
-        outfiles = [stack.enter_context(open(p, "wb")) for p in dest_paths]
+        infile = stack.enter_context(Path(source_path).open("rb"))
+        outfiles = [
+            stack.enter_context(Path(path).open("wb"))
+            for path in dest_paths
+        ]
         split_io(infile, list(outfiles), bufsize=bufsize)
 
 
 def merge_main(
-    *, dest_path: str, source_paths: str, bufsize: int = 1024
+    *, dest_path: str, source_paths: list[str], bufsize: int = 1024,
 ) -> None:
     # ensure closing all the files even if an exception is raised
     with ExitStack() as stack:
-        outfile = stack.enter_context(open(dest_path, "wb"))
-        infiles = [stack.enter_context(open(p, "rb")) for p in source_paths]
+        outfile = stack.enter_context(Path(dest_path).open("wb"))
+        infiles = [
+            stack.enter_context(Path(path).open("rb"))
+            for path in source_paths
+        ]
         merge_io(infiles, outfile, bufsize=bufsize)
 
 
@@ -34,24 +41,26 @@ def main() -> None:
         help=(
             "Commands:\n"
             "split: split a file into multiple files\n"
-            "merge: merge multiple files into a file"
+            "merge: merge multiple files into a file\n"
             "Example:\n"
-            "tally-token split example.bin example.bin.1 example.bin.2 example.bin.3\n"
-            "tally-token merge example-merged.bin example.bin.1 example.bin.2 example.bin.3"
+            "tally-token split example.bin "
+            "example.bin.1 example.bin.2 example.bin.3\n"
+            "tally-token merge example-merged.bin "
+            "example.bin.1 example.bin.2 example.bin.3"
         ),
     )
     split_parser = subparsers.add_parser("split")
     split_parser.add_argument("src", help="The source file to be split.")
     split_parser.add_argument("dst", nargs="+", help="The destination files.")
     split_parser.add_argument(
-        "--bufsize", type=int, default=1024 * 2, help="The buffer size."
+        "--bufsize", type=int, default=1024 * 2, help="The buffer size.",
     )
 
     merge_parser = subparsers.add_parser("merge")
     merge_parser.add_argument("dst", help="The destination file.")
     merge_parser.add_argument("src", nargs="+", help="The source files.")
     merge_parser.add_argument(
-        "--bufsize", type=int, default=1024**2, help="The buffer size."
+        "--bufsize", type=int, default=1024**2, help="The buffer size.",
     )
 
     args = parser.parse_args()

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1,5 +1,9 @@
 import random
-from tally_token import split_text, merge_text, split_bytes_into, merge_bytes_into
+
+from tally_token import (
+    merge_text,
+    split_text,
+)
 
 
 def test_split_merge():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,22 +16,37 @@ def test_cli():
         # split the file
         subprocess.check_call(
             [
-                "python", "-m", "tally_token", "split", f"{tmpdir}/example.bin",
-                f"{tmpdir}/example.bin.1", f"{tmpdir}/example.bin.2", f"{tmpdir}/example.bin.3",
+                "python",
+                "-m",
+                "tally_token",
+                "split",
+                f"{tmpdir}/example.bin",
+                f"{tmpdir}/example.bin.1",
+                f"{tmpdir}/example.bin.2",
+                f"{tmpdir}/example.bin.3",
             ],
         )
 
         # merge the split files
         subprocess.check_call(
             [
-                "python", "-m", "tally_token", "merge", f"{tmpdir}/example-merged.bin",
-                f"{tmpdir}/example.bin.1", f"{tmpdir}/example.bin.2", f"{tmpdir}/example.bin.3",
+                "python",
+                "-m",
+                "tally_token",
+                "merge",
+                f"{tmpdir}/example-merged.bin",
+                f"{tmpdir}/example.bin.1",
+                f"{tmpdir}/example.bin.2",
+                f"{tmpdir}/example.bin.3",
             ],
         )
 
         # check that the original file and the merged file are the same
         subprocess.check_call(
             [
-                "diff", "-s", f"{tmpdir}/example.bin", f"{tmpdir}/example-merged.bin",
+                "diff",
+                "-s",
+                f"{tmpdir}/example.bin",
+                f"{tmpdir}/example-merged.bin",
             ],
         )


### PR DESCRIPTION
## Summary

Tighten the Ruff lint configuration with a stricter, low-friction rule set.

## Changes

- enable a broader set of non-framework-specific Ruff rules
- keep test files practical with targeted per-file ignores where needed
- update code that was auto-fixable or low-cost to adjust manually

## Verification

- `uv run poe check`
- `uv run poe test`
