### PR TITLE
Tighten Ruff McCabe complexity limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,4 +106,4 @@ select = [
 ]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 4
+max-complexity = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,6 @@ select = [
     "S101",
     "S607",
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 4

--- a/tally_token/__init__.py
+++ b/tally_token/__init__.py
@@ -42,11 +42,22 @@ def split_io(
     """
     output_sizes = len(outfiles)
     for buf in iter(lambda: infile.read(bufsize), b""):
-        token_bytes = split_bytes_into(buf, output_sizes)
-        for token, outfile in zip(token_bytes, outfiles, strict=False):
-            outfile.write(token)
+        write_split_tokens(buf, outfiles, output_sizes)
 
-    # flush all the files
+    flush_outputs(outfiles)
+
+
+def write_split_tokens(
+    source: bytes,
+    outfiles: list[BufferedWriter],
+    output_sizes: int,
+) -> None:
+    token_bytes = split_bytes_into(source, output_sizes)
+    for token, outfile in zip(token_bytes, outfiles, strict=False):
+        outfile.write(token)
+
+
+def flush_outputs(outfiles: list[BufferedWriter]) -> None:
     for outfile in outfiles:
         outfile.flush()
 


### PR DESCRIPTION
## Summary
- add Ruff McCabe `max-complexity = 4`
- lower the limit to `3`
- split token writing and output flushing into focused helpers

## Testing
- `uv run poe check`
- `uv run poe test`

## Notes
- `uv run poe build` currently fails because `build` is not installed in the project environment