### PR TITLE
ci: set read-only workflow permissions for publish

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,12 +7,17 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+permissions:
+  contents: read
+
 env:
   python_version: 3.13
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

Add explicit workflow and job permissions (`contents: read`) to the PyPI publish workflow to apply least privilege and keep publication behavior unchanged.

## Why

The `pypi-publish` workflow currently relies on inherited token defaults.

## Validation

- `uv sync --no-dev`
- `uv run poe check`

## Baseline

baseline-ci-permissions-001
