### PR TITLE
Restrict test workflow permissions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit read-only `contents` permission to the Python test workflow.

## Verification
- `git diff --check`
- `actionlint .github/workflows/python-test.yml`