### PR TITLE
Validate token lengths before merging

### DIFF
--- a/tally_token/__init__.py
+++ b/tally_token/__init__.py
@@ -14,7 +14,10 @@ from ._version import __version__
 
 
 def split_text(
-    clear_text: str, into: int = 2, *, encoding: str = "utf-8",
+    clear_text: str,
+    into: int = 2,
+    *,
+    encoding: str = "utf-8",
 ) -> list[bytes]:
     """Split a text into multiple tokens.
 
@@ -101,6 +104,12 @@ def merge_bytes_into(tokens: list[bytes]) -> bytes:
     """
     token = tokens[0]
     for i in range(1, len(tokens)):
+        if len(tokens[i]) != len(token):
+            msg = (
+                f"token at index {i} has length {len(tokens[i])}, "
+                f"expected {len(token)}"
+            )
+            raise ValueError(msg)
         token = _merge1(token, tokens[i])
     return token
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1,6 +1,11 @@
 import random
+from io import BytesIO
+
+import pytest
 
 from tally_token import (
+    merge_bytes_into,
+    merge_io,
     merge_text,
     split_text,
 )
@@ -17,7 +22,7 @@ def test_split_into_one_and_merge():
     """Test that split_text with into=1 returns the original text."""
     clear_text = "Hello World!"
     tokens = split_text(clear_text, into=1)
-    assert tokens == [b'Hello World!']
+    assert tokens == [b"Hello World!"]
     assert clear_text == merge_text(tokens)
 
 
@@ -38,6 +43,29 @@ def test_merge_order():
     for _ in range(10):
         random.shuffle(tokens)
         assert clear_text == merge_text(tokens)
+
+
+def test_merge_bytes_into_rejects_mismatched_token_lengths():
+    """Test that merge_bytes_into rejects mismatched token lengths."""
+    token1, token2 = split_text("Hello World!")
+
+    with pytest.raises(
+        ValueError,
+        match="token at index 1 has length 11, expected 12",
+    ):
+        merge_bytes_into([token1, token2[:-1]])
+
+
+def test_merge_io_rejects_mismatched_token_lengths():
+    """Test that merge_io rejects mismatched token lengths."""
+    token1, token2 = split_text("Hello World!")
+    output = BytesIO()
+
+    with pytest.raises(
+        ValueError,
+        match="token at index 1 has length 11, expected 12",
+    ):
+        merge_io([BytesIO(token1), BytesIO(token2[:-1])], output)
 
 
 def test_encoding():


### PR DESCRIPTION
## Summary

- Validate token chunk lengths before merging them.
- Raise a `ValueError` that points to the mismatched token index and length.
- Add regression coverage for both the bytes API and file-like merge API.

## Verification

- `uv run poe test`
- `uv run poe check`
- `uv run ruff check tests/test_basis.py`
- `uv run ruff format --check tally_token/__init__.py tests/test_basis.py`
- `git diff --check`
