### PR TITLE
Pin workflow action refs to 40-character commit SHAs

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,10 +19,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Enable caching
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 
@@ -34,7 +34,7 @@ jobs:
         run: uv build
 
       - name: Publish distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
           user: __token__
@@ -43,7 +43,7 @@ jobs:
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "${{ matrix.python }}"
 
       - name: Enable caching and setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@3717c78af3a5e594b7a81b063276e15fac7e08fc # main


### PR DESCRIPTION
## Summary

Pin the external `uses:` references flagged by the supply-chain audit (`kitsuyui/kimono-tasks#github-actions-action-ref-not-pinned-001`) to 40-character commit SHAs:

| File | Before | After |
| --- | --- | --- |
| `python-test.yml:22` | `actions/checkout@v6` | `@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6` |
| `python-test.yml:26` | `actions/setup-python@v6` | `@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6` |
| `python-test.yml:31` | `astral-sh/setup-uv@v7` | `@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7` |
| `pypi-publish.yml:22` | `actions/checkout@v6` | `@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6` |
| `pypi-publish.yml:25` | `astral-sh/setup-uv@v7` | `@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7` |
| `pypi-publish.yml:37` | `pypa/gh-action-pypi-publish@release/v1` | `@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1` |
| `pypi-publish.yml:46` | `pypa/gh-action-pypi-publish@release/v1` | `@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1` |
| `spellcheck.yml:8` | `kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main` | `@3717c78af3a5e594b7a81b063276e15fac7e08fc # main` |

The `astral-sh/setup-uv@v7` SHA matches the value already in use by `octocov.yml` in this same repository. The reusable workflow SHA (`3717c78af3a5e594b7a81b063276e15fac7e08fc`) matches the values already in use by `gitignore-in.yml` and `happy.yml` in this same repository. The remaining SHAs match values already adopted across other kitsuyui org repos. Behavior is therefore unchanged.

Renovate already extends `helpers:pinGitHubActionDigests` via `local>kitsuyui/renovate-config`, so future digest updates continue through automated PRs.

## Test plan

- [x] `git diff --check` clean
- [x] `actionlint` on the three changed workflows passes
- [x] SHAs verified against existing pinned uses in this repo / other org repos