### PR TITLE
Add workflow concurrency controls

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,6 +7,10 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Summary
- Add top-level concurrency groups to the test, coverage, and packaging workflows.
- Cancel superseded branch and pull request runs so newer commits are not blocked behind obsolete CI work.
- Keep release publishing runs from being canceled by limiting packaging cancellation to pull requests.

## Verification
- actionlint .github/workflows/octocov.yml .github/workflows/pypi-publish.yml .github/workflows/python-test.yml
- git diff --check
- uv run poe check
- uv run poe test
