### PR TITLE
fix: flush output buffer in merge_io after writing

### DIFF
--- a/tally_token/__init__.py
+++ b/tally_token/__init__.py
@@ -144,6 +144,7 @@ def merge_io(
         if not clear_text_bytes:
             break
         outfile.write(clear_text_bytes)
+    outfile.flush()
 
 
 def _generate_random_token(size: int) -> bytes:

--- a/tally_token/__main__.py
+++ b/tally_token/__main__.py
@@ -8,27 +8,31 @@ from tally_token import merge_io, split_io
 
 
 def split_main(
-    *, source_path: str, dest_paths: list[str], bufsize: int = 1024,
+    *,
+    source_path: str,
+    dest_paths: list[str],
+    bufsize: int = 1024,
 ) -> None:
     # ensure closing all the files even if an exception is raised
     with ExitStack() as stack:
         infile = stack.enter_context(Path(source_path).open("rb"))
         outfiles = [
-            stack.enter_context(Path(path).open("wb"))
-            for path in dest_paths
+            stack.enter_context(Path(path).open("wb")) for path in dest_paths
         ]
         split_io(infile, list(outfiles), bufsize=bufsize)
 
 
 def merge_main(
-    *, dest_path: str, source_paths: list[str], bufsize: int = 1024,
+    *,
+    dest_path: str,
+    source_paths: list[str],
+    bufsize: int = 1024,
 ) -> None:
     # ensure closing all the files even if an exception is raised
     with ExitStack() as stack:
         outfile = stack.enter_context(Path(dest_path).open("wb"))
         infiles = [
-            stack.enter_context(Path(path).open("rb"))
-            for path in source_paths
+            stack.enter_context(Path(path).open("rb")) for path in source_paths
         ]
         merge_io(infiles, outfile, bufsize=bufsize)
 
@@ -53,14 +57,20 @@ def main() -> None:
     split_parser.add_argument("src", help="The source file to be split.")
     split_parser.add_argument("dst", nargs="+", help="The destination files.")
     split_parser.add_argument(
-        "--bufsize", type=int, default=1024 * 2, help="The buffer size.",
+        "--bufsize",
+        type=int,
+        default=1024 * 2,
+        help="The buffer size.",
     )
 
     merge_parser = subparsers.add_parser("merge")
     merge_parser.add_argument("dst", help="The destination file.")
     merge_parser.add_argument("src", nargs="+", help="The source files.")
     merge_parser.add_argument(
-        "--bufsize", type=int, default=1024**2, help="The buffer size.",
+        "--bufsize",
+        type=int,
+        default=1024**2,
+        help="The buffer size.",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Summary

`merge_io` writes data to `outfile` but never calls `outfile.flush()` before returning.
`split_io` already calls `flush_outputs(outfiles)` explicitly at the end; `merge_io` was asymmetrically missing the same guarantee.

Without an explicit flush, callers that do not close or context-manage `outfile` risk:
- losing buffered data when the process ends or the object is garbage-collected
- leaving a partial write on disk if an IO error occurs mid-read

## Changes

- `tally_token/__init__.py`: add `outfile.flush()` after the write loop in `merge_io`
- `tally_token/__main__.py`: reformatted by ruff (trailing commas → expanded keyword arguments; no logic change)

## Verification

- `poe check` (ruff + mypy): all checks passed
- `poe test` (pytest): 8/8 passed
