### PR TITLE
fix: require explicit --output flag for merge subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ usage: tally-token [-h] {split,merge} ...
 
 positional arguments:
   {split,merge}  Commands: split: split a file into multiple files merge: merge multiple files into a fileExample: tally-token split example.bin
-                 example.bin.1 example.bin.2 example.bin.3 tally-token merge example-merged.bin example.bin.1 example.bin.2 example.bin.3
+                 example.bin.1 example.bin.2 example.bin.3 tally-token merge example.bin.1 example.bin.2 example.bin.3 --output example-merged.bin
 
 options:
   -h, --help     show this help message and exit
@@ -49,7 +49,7 @@ $ tally-token split something.bin split-1.bin split-2.bin split-3.bin
 You can use `merge` to merge multiple files into a file.
 
 ```sh
-$ tally-token merge merged.bin split-1.bin split-2.bin split-3.bin
+$ tally-token merge split-1.bin split-2.bin split-3.bin --output merged.bin
 ```
 
 ### Large files
@@ -61,7 +61,7 @@ $ dd if=/dev/urandom of=original.1g.bin bs=1G count=1
 $ tally-token split original.1g.bin split-1.bin split-2.bin split-3.bin
 $ shasum -a 256 original.1g.bin
 > 736a344d99d27e2dcdab8bc37ca94c83eda26f812a3dee87ac98989f89b3f965 original.1g.bin
-$ tally-token merge recovery.1g.bin split-1.bin split-2.bin split-3.bin
+$ tally-token merge split-1.bin split-2.bin split-3.bin --output recovery.1g.bin
 $ shasum -a 256 recovery.1g.bin
 > 736a344d99d27e2dcdab8bc37ca94c83eda26f812a3dee87ac98989f89b3f965 recovery.1g.bin
 ```

--- a/tally_token/__main__.py
+++ b/tally_token/__main__.py
@@ -8,27 +8,31 @@ from tally_token import merge_io, split_io
 
 
 def split_main(
-    *, source_path: str, dest_paths: list[str], bufsize: int = 1024,
+    *,
+    source_path: str,
+    dest_paths: list[str],
+    bufsize: int = 1024,
 ) -> None:
     # ensure closing all the files even if an exception is raised
     with ExitStack() as stack:
         infile = stack.enter_context(Path(source_path).open("rb"))
         outfiles = [
-            stack.enter_context(Path(path).open("wb"))
-            for path in dest_paths
+            stack.enter_context(Path(path).open("wb")) for path in dest_paths
         ]
         split_io(infile, list(outfiles), bufsize=bufsize)
 
 
 def merge_main(
-    *, dest_path: str, source_paths: list[str], bufsize: int = 1024,
+    *,
+    dest_path: str,
+    source_paths: list[str],
+    bufsize: int = 1024,
 ) -> None:
     # ensure closing all the files even if an exception is raised
     with ExitStack() as stack:
         outfile = stack.enter_context(Path(dest_path).open("wb"))
         infiles = [
-            stack.enter_context(Path(path).open("rb"))
-            for path in source_paths
+            stack.enter_context(Path(path).open("rb")) for path in source_paths
         ]
         merge_io(infiles, outfile, bufsize=bufsize)
 
@@ -45,29 +49,41 @@ def main() -> None:
             "Example:\n"
             "tally-token split example.bin "
             "example.bin.1 example.bin.2 example.bin.3\n"
-            "tally-token merge example-merged.bin "
-            "example.bin.1 example.bin.2 example.bin.3"
+            "tally-token merge "
+            "example.bin.1 example.bin.2 example.bin.3 "
+            "--output example-merged.bin"
         ),
     )
     split_parser = subparsers.add_parser("split")
     split_parser.add_argument("src", help="The source file to be split.")
     split_parser.add_argument("dst", nargs="+", help="The destination files.")
     split_parser.add_argument(
-        "--bufsize", type=int, default=1024 * 2, help="The buffer size.",
+        "--bufsize",
+        type=int,
+        default=1024 * 2,
+        help="The buffer size.",
     )
 
     merge_parser = subparsers.add_parser("merge")
-    merge_parser.add_argument("dst", help="The destination file.")
     merge_parser.add_argument("src", nargs="+", help="The source files.")
     merge_parser.add_argument(
-        "--bufsize", type=int, default=1024**2, help="The buffer size.",
+        "--output",
+        "-o",
+        required=True,
+        help="The destination file.",
+    )
+    merge_parser.add_argument(
+        "--bufsize",
+        type=int,
+        default=1024**2,
+        help="The buffer size.",
     )
 
     args = parser.parse_args()
     if args.command == "split":
         split_main(source_path=args.src, dest_paths=args.dst)
     elif args.command == "merge":
-        merge_main(dest_path=args.dst, source_paths=args.src)
+        merge_main(dest_path=args.output, source_paths=args.src)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,10 +34,11 @@ def test_cli():
                 "-m",
                 "tally_token",
                 "merge",
-                f"{tmpdir}/example-merged.bin",
                 f"{tmpdir}/example.bin.1",
                 f"{tmpdir}/example.bin.2",
                 f"{tmpdir}/example.bin.3",
+                "--output",
+                f"{tmpdir}/example-merged.bin",
             ],
         )
 


### PR DESCRIPTION
## Summary

- `merge` subcommand previously accepted `<dst> <src...>` (output-first, then inputs),
  while `split` accepts `<src> <dst...>` (input-first, then outputs).
- A user familiar with `split` could accidentally run `tally-token merge token1.bin token2.bin out.bin`
  intending `out.bin` as the destination, but the old CLI treated `token1.bin` as the output — silently
  overwriting it with corrupt data.
- This PR changes `merge` to require an explicit `--output`/`-o` flag for the destination file,
  with the positional arguments now being the source files:

```
# before (output first — dangerous inconsistency with split)
tally-token merge merged.bin split-1.bin split-2.bin split-3.bin

# after (sources first, explicit output flag — consistent with split's input-first order)
tally-token merge split-1.bin split-2.bin split-3.bin --output merged.bin
```

## Changes

- `tally_token/__main__.py`: `merge` subparser now takes `src` as positionals and `--output`/`-o` as a required named option
- `tests/test_cli.py`: updated CLI test to use the new syntax
- `README.md`: updated all merge usage examples

## Test evidence

```
$ uv run pytest tests/ -v
8 passed in 1.48s
```

## Trade-offs

This is a breaking change for scripts using the old `<dst> <src...>` positional syntax.
The change is intentional: the old interface had a high data-loss risk (silent overwrite of the wrong file)
that outweighs backward compatibility for a security-sensitive utility.