### PR TITLE
refactor: harmonize split_bytes_into param name and mark helpers private

### DIFF
--- a/tally_token/__init__.py
+++ b/tally_token/__init__.py
@@ -45,12 +45,12 @@ def split_io(
     """
     output_sizes = len(outfiles)
     for buf in iter(lambda: infile.read(bufsize), b""):
-        write_split_tokens(buf, outfiles, output_sizes)
+        _write_split_tokens(buf, outfiles, output_sizes)
 
-    flush_outputs(outfiles)
+    _flush_outputs(outfiles)
 
 
-def write_split_tokens(
+def _write_split_tokens(
     source: bytes,
     outfiles: list[BufferedWriter],
     output_sizes: int,
@@ -60,7 +60,7 @@ def write_split_tokens(
         outfile.write(token)
 
 
-def flush_outputs(outfiles: list[BufferedWriter]) -> None:
+def _flush_outputs(outfiles: list[BufferedWriter]) -> None:
     for outfile in outfiles:
         outfile.flush()
 
@@ -73,16 +73,16 @@ def _split1(source: bytes) -> tuple[bytes, bytes]:
     return bytes(token), bytes(cipher_text)
 
 
-def split_bytes_into(source: bytes, n: int) -> list[bytes]:
+def split_bytes_into(source: bytes, into: int) -> list[bytes]:
     """Split a bytes into multiple token bytes.
 
     Args:
         source: The bytes to be split.
-        n: The number of tokens to be generated.
+        into: The number of tokens to be generated.
     """
     tokens = []
     token = source
-    for _ in range(n - 1):
+    for _ in range(into - 1):
         generated, token = _split1(token)
         tokens.append(generated)
     tokens.append(token)


### PR DESCRIPTION
## Summary

Two API surface inconsistencies addressed in `tally_token/__init__.py`:

1. **Parameter name inconsistency**: `split_text` uses `into: int` for the token count, but
   `split_bytes_into` used `n: int` for the same concept. Callers using both functions had to
   remember two different names for the same thing. Renamed `n` → `into` to match.

2. **Ambiguous public API boundary**: `write_split_tokens` and `flush_outputs` were
   implementation details of `split_io` — not listed in `__all__`, not documented — but lacked
   the underscore prefix that signals a private function. Renamed to `_write_split_tokens` and
   `_flush_outputs` to make the intent explicit.

## Changes

- `tally_token/__init__.py`:
  - `split_bytes_into(source, n)` → `split_bytes_into(source, into)`
  - `write_split_tokens` → `_write_split_tokens`
  - `flush_outputs` → `_flush_outputs`
  - Callers in `split_io` updated accordingly

## Breaking changes

- **`split_bytes_into` keyword callers**: `split_bytes_into(data, n=5)` must change to
  `split_bytes_into(data, into=5)`. Positional callers `split_bytes_into(data, 5)` are
  unaffected.
- **`write_split_tokens` / `flush_outputs`**: Any code directly importing these names will
  break. Neither was in `__all__` nor documented; they were unintentionally accessible.

## Test evidence

```
$ uv run pytest tests/ -v
8 passed in 1.44s
```