### PR TITLE
fix: honor --bufsize option in split and merge subcommands

### DIFF
--- a/tally_token/__main__.py
+++ b/tally_token/__main__.py
@@ -65,9 +65,13 @@ def main() -> None:
 
     args = parser.parse_args()
     if args.command == "split":
-        split_main(source_path=args.src, dest_paths=args.dst)
+        split_main(
+            source_path=args.src, dest_paths=args.dst, bufsize=args.bufsize,
+        )
     elif args.command == "merge":
-        merge_main(dest_path=args.dst, source_paths=args.src)
+        merge_main(
+            dest_path=args.dst, source_paths=args.src, bufsize=args.bufsize,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The `--bufsize` option was parsed by argparse but never forwarded to the underlying
`split_main` / `merge_main` functions. As a result, any user-specified buffer size
was silently ignored and the hard-coded function default (1024 bytes) was always used.

Additionally, the CLI defaults and function defaults were inconsistent:
- `split --bufsize` default: 2048, `split_main` default: 1024
- `merge --bufsize` default: 1048576 (1 MiB), `merge_main` default: 1024

## Change

Pass `bufsize=args.bufsize` to both `split_main` and `merge_main` calls in `main()`.

## Before / After

```python
# Before — bufsize from CLI was dropped
split_main(source_path=args.src, dest_paths=args.dst)
merge_main(dest_path=args.dst, source_paths=args.src)

# After — bufsize forwarded correctly
split_main(source_path=args.src, dest_paths=args.dst, bufsize=args.bufsize)
merge_main(dest_path=args.dst, source_paths=args.src, bufsize=args.bufsize)
```

## Test evidence

```
$ uv run pytest tests/ -v
8 passed in 1.42s
```