### PR TITLE
fix: register tally-token CLI entry point in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Intended Audience :: Developers",
 ]
+[project.scripts]
+tally-token = "tally_token.__main__:main"
+
 [project.urls]
 Homepage = "https://github.com/kitsuyui/python-tally-token"
 

--- a/tally_token/__main__.py
+++ b/tally_token/__main__.py
@@ -8,27 +8,31 @@ from tally_token import merge_io, split_io
 
 
 def split_main(
-    *, source_path: str, dest_paths: list[str], bufsize: int = 1024,
+    *,
+    source_path: str,
+    dest_paths: list[str],
+    bufsize: int = 1024,
 ) -> None:
     # ensure closing all the files even if an exception is raised
     with ExitStack() as stack:
         infile = stack.enter_context(Path(source_path).open("rb"))
         outfiles = [
-            stack.enter_context(Path(path).open("wb"))
-            for path in dest_paths
+            stack.enter_context(Path(path).open("wb")) for path in dest_paths
         ]
         split_io(infile, list(outfiles), bufsize=bufsize)
 
 
 def merge_main(
-    *, dest_path: str, source_paths: list[str], bufsize: int = 1024,
+    *,
+    dest_path: str,
+    source_paths: list[str],
+    bufsize: int = 1024,
 ) -> None:
     # ensure closing all the files even if an exception is raised
     with ExitStack() as stack:
         outfile = stack.enter_context(Path(dest_path).open("wb"))
         infiles = [
-            stack.enter_context(Path(path).open("rb"))
-            for path in source_paths
+            stack.enter_context(Path(path).open("rb")) for path in source_paths
         ]
         merge_io(infiles, outfile, bufsize=bufsize)
 
@@ -53,14 +57,20 @@ def main() -> None:
     split_parser.add_argument("src", help="The source file to be split.")
     split_parser.add_argument("dst", nargs="+", help="The destination files.")
     split_parser.add_argument(
-        "--bufsize", type=int, default=1024 * 2, help="The buffer size.",
+        "--bufsize",
+        type=int,
+        default=1024 * 2,
+        help="The buffer size.",
     )
 
     merge_parser = subparsers.add_parser("merge")
     merge_parser.add_argument("dst", help="The destination file.")
     merge_parser.add_argument("src", nargs="+", help="The source files.")
     merge_parser.add_argument(
-        "--bufsize", type=int, default=1024**2, help="The buffer size.",
+        "--bufsize",
+        type=int,
+        default=1024**2,
+        help="The buffer size.",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Problem

`pyproject.toml` had no `[project.scripts]` section, so `pip install tally-token` did not create a `tally-token` console script. Users following the README examples would see:

```
tally-token: command not found
```

The `main()` function existed in `tally_token/__main__.py` and worked via `python -m tally_token`, but no entry point was registered for the installed `tally-token` command.

## Change

Add `[project.scripts]` to `pyproject.toml`:

```toml
[project.scripts]
tally-token = "tally_token.__main__:main"
```

## Verification

- `uv sync` rebuilds the package with the entry point registered
- `tally-token --help` now shows the split/merge subcommands
- All 8 existing tests pass
- `ruff check` and `mypy` pass