### PR TITLE
fix: use temp-write-then-rename for atomic output in split and merge

### DIFF
--- a/tally_token/__main__.py
+++ b/tally_token/__main__.py
@@ -1,36 +1,77 @@
 from __future__ import annotations
 
 import argparse
+import os
+import tempfile
 from contextlib import ExitStack
+from io import BufferedWriter
 from pathlib import Path
 
 from tally_token import merge_io, split_io
 
 
+def _open_temp_writers(
+    dest_paths: list[Path],
+    stack: ExitStack,
+) -> tuple[list[Path], list[BufferedWriter]]:
+    tmp_paths: list[Path] = []
+    outfiles: list[BufferedWriter] = []
+    for dest in dest_paths:
+        fd, tmp = tempfile.mkstemp(dir=dest.parent)
+        tmp_paths.append(Path(tmp))
+        outfiles.append(stack.enter_context(os.fdopen(fd, "wb")))
+    return tmp_paths, outfiles
+
+
+def _unlink_temps(tmp_paths: list[Path]) -> None:
+    for tmp_path in tmp_paths:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _rename_temps(tmp_paths: list[Path], dest_paths: list[Path]) -> None:
+    for tmp_path, dest in zip(tmp_paths, dest_paths, strict=True):
+        tmp_path.replace(dest)
+
+
 def split_main(
-    *, source_path: str, dest_paths: list[str], bufsize: int = 1024,
+    *,
+    source_path: str,
+    dest_paths: list[str],
+    bufsize: int = 1024,
 ) -> None:
-    # ensure closing all the files even if an exception is raised
-    with ExitStack() as stack:
-        infile = stack.enter_context(Path(source_path).open("rb"))
-        outfiles = [
-            stack.enter_context(Path(path).open("wb"))
-            for path in dest_paths
-        ]
-        split_io(infile, list(outfiles), bufsize=bufsize)
+    dest_path_objects = [Path(p) for p in dest_paths]
+    tmp_paths: list[Path] = []
+    try:
+        with ExitStack() as stack:
+            infile = stack.enter_context(Path(source_path).open("rb"))
+            tmp_paths, outfiles = _open_temp_writers(dest_path_objects, stack)
+            split_io(infile, outfiles, bufsize=bufsize)
+        _rename_temps(tmp_paths, dest_path_objects)
+    except Exception:
+        _unlink_temps(tmp_paths)
+        raise
 
 
 def merge_main(
-    *, dest_path: str, source_paths: list[str], bufsize: int = 1024,
+    *,
+    dest_path: str,
+    source_paths: list[str],
+    bufsize: int = 1024,
 ) -> None:
-    # ensure closing all the files even if an exception is raised
-    with ExitStack() as stack:
-        outfile = stack.enter_context(Path(dest_path).open("wb"))
-        infiles = [
-            stack.enter_context(Path(path).open("rb"))
-            for path in source_paths
-        ]
-        merge_io(infiles, outfile, bufsize=bufsize)
+    dest = Path(dest_path)
+    fd, tmp = tempfile.mkstemp(dir=dest.parent)
+    tmp_path = Path(tmp)
+    try:
+        with ExitStack() as stack:
+            outfile: BufferedWriter = stack.enter_context(os.fdopen(fd, "wb"))
+            infiles = [
+                stack.enter_context(Path(p).open("rb")) for p in source_paths
+            ]
+            merge_io(infiles, outfile, bufsize=bufsize)
+        tmp_path.replace(dest)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def main() -> None:
@@ -53,14 +94,20 @@ def main() -> None:
     split_parser.add_argument("src", help="The source file to be split.")
     split_parser.add_argument("dst", nargs="+", help="The destination files.")
     split_parser.add_argument(
-        "--bufsize", type=int, default=1024 * 2, help="The buffer size.",
+        "--bufsize",
+        type=int,
+        default=1024 * 2,
+        help="The buffer size.",
     )
 
     merge_parser = subparsers.add_parser("merge")
     merge_parser.add_argument("dst", help="The destination file.")
     merge_parser.add_argument("src", nargs="+", help="The source files.")
     merge_parser.add_argument(
-        "--bufsize", type=int, default=1024**2, help="The buffer size.",
+        "--bufsize",
+        type=int,
+        default=1024**2,
+        help="The buffer size.",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Problem

`split_main` and `merge_main` wrote directly to the final output files. If the process was interrupted mid-write (crash, SIGKILL, disk full), partial files would remain on disk:

- For `split`: some token files complete, others truncated — a set that cannot be recovered.
- For `merge`: partial plaintext left on disk even if the operation was retried.

## Change

Both functions now use a temp-write-then-rename pattern:

1. Write to `tempfile.mkstemp` files in the **same directory** as the destination (ensuring rename is atomic on POSIX — same filesystem, single syscall).
2. Close all temp files via `ExitStack`.
3. Rename each temp file to its final path.

On failure at any stage, temp files are unlinked before the exception propagates. On success, rename is atomic.

Helper functions extracted to keep each function within the cyclomatic complexity limit (`max-complexity = 3`):
- `_open_temp_writers`: creates temp files and registers them with `ExitStack`
- `_unlink_temps`: cleans up temp files on failure
- `_rename_temps`: renames temp files to final destinations

## Verification

- All 8 existing tests pass
- `ruff check` and `mypy --strict` pass
- Security check (`ruff check --select S`) passes