### PR TITLE
fix: raise ValueError when merging tokens from different splits

### DIFF
--- a/tally_token/__init__.py
+++ b/tally_token/__init__.py
@@ -15,6 +15,8 @@ from ._version import __version__
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
+_SESSION_ID_SIZE = 16
+
 
 def split_text(
     clear_text: str,
@@ -48,19 +50,22 @@ def split_io(
         outfiles: The files to be written.
         bufsize: The buffer size of reading and writing.
     """
+    session_id = _generate_random_token(_SESSION_ID_SIZE)
+    for outfile in outfiles:
+        outfile.write(session_id)
     output_sizes = len(outfiles)
     for buf in iter(lambda: infile.read(bufsize), b""):
-        _write_split_tokens(buf, outfiles, output_sizes)
+        _write_split_tokens_raw(buf, outfiles, output_sizes)
 
     _flush_outputs(outfiles)
 
 
-def _write_split_tokens(
+def _write_split_tokens_raw(
     source: bytes,
     outfiles: list[BufferedWriter],
     output_sizes: int,
 ) -> None:
-    token_bytes = split_bytes_into(source, output_sizes)
+    token_bytes = _split_bytes_raw(source, output_sizes)
     for token, outfile in zip(token_bytes, outfiles, strict=False):
         outfile.write(token)
 
@@ -78,13 +83,8 @@ def _split1(source: bytes) -> tuple[bytes, bytes]:
     return bytes(token), bytes(cipher_text)
 
 
-def split_bytes_into(source: bytes, into: int) -> list[bytes]:
-    """Split a bytes into multiple token bytes.
-
-    Args:
-        source: The bytes to be split.
-        into: The number of tokens to be generated.
-    """
+def _split_bytes_raw(source: bytes, into: int) -> list[bytes]:
+    """Split bytes into raw tokens without session ID (for streaming use)."""
     tokens = []
     token = source
     for _ in range(into - 1):
@@ -94,6 +94,21 @@ def split_bytes_into(source: bytes, into: int) -> list[bytes]:
     return tokens
 
 
+def split_bytes_into(source: bytes, into: int) -> list[bytes]:
+    """Split a bytes into multiple token bytes.
+
+    Each token is prefixed with a shared 16-byte session ID so that
+    merge_bytes_into can detect when tokens from different splits are mixed.
+
+    Args:
+        source: The bytes to be split.
+        into: The number of tokens to be generated.
+    """
+    session_id = _generate_random_token(_SESSION_ID_SIZE)
+    raw_tokens = _split_bytes_raw(source, into)
+    return [session_id + t for t in raw_tokens]
+
+
 def _merge1(token1: bytes, token2: bytes) -> bytes:
     clear_text = bytearray()
     for i in range(len(token1)):
@@ -101,12 +116,8 @@ def _merge1(token1: bytes, token2: bytes) -> bytes:
     return bytes(clear_text)
 
 
-def merge_bytes_into(tokens: list[bytes]) -> bytes:
-    """Merge tokens into a secret bytes.
-
-    Args:
-        tokens: The tokens to be merged.
-    """
+def _merge_bytes_raw(tokens: list[bytes]) -> bytes:
+    """Merge raw token chunks without session ID verification."""
     token = tokens[0]
     for i in range(1, len(tokens)):
         if len(tokens[i]) != len(token):
@@ -117,6 +128,30 @@ def merge_bytes_into(tokens: list[bytes]) -> bytes:
             raise ValueError(msg)
         token = _merge1(token, tokens[i])
     return token
+
+
+def _check_session_ids(session_ids: list[bytes]) -> None:
+    """Raise ValueError if session IDs from different splits are detected."""
+    if len(set(session_ids)) > 1:
+        raise ValueError(
+            "tokens come from different splits: session IDs do not match",
+        )
+
+
+def merge_bytes_into(tokens: list[bytes]) -> bytes:
+    """Merge tokens into a secret bytes.
+
+    Verifies that all tokens share the same session ID embedded by
+    split_bytes_into, raising ValueError if tokens from different splits
+    are mixed.
+
+    Args:
+        tokens: The tokens to be merged.
+    """
+    session_ids = [t[:_SESSION_ID_SIZE] for t in tokens]
+    _check_session_ids(session_ids)
+    stripped = [t[_SESSION_ID_SIZE:] for t in tokens]
+    return _merge_bytes_raw(stripped)
 
 
 def merge_text(tokens: list[bytes], *, encoding: str = "utf-8") -> str:
@@ -144,13 +179,14 @@ def merge_io(
         infiles: The files to be read.
         outfile: The file to be written.
     """
-    token_bytes = []
+    session_ids = [f.read(_SESSION_ID_SIZE) for f in infiles]
+    _check_session_ids(session_ids)
     while True:
-        token_bytes = [infile.read(bufsize) for infile in infiles]
-        clear_text_bytes = merge_bytes_into(token_bytes)
-        if not clear_text_bytes:
+        chunks = [f.read(bufsize) for f in infiles]
+        merged = _merge_bytes_raw(chunks)
+        if not merged:
             break
-        outfile.write(clear_text_bytes)
+        outfile.write(merged)
     outfile.flush()
 
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -7,6 +7,7 @@ from tally_token import (
     merge_bytes_into,
     merge_io,
     merge_text,
+    split_bytes_into,
     split_text,
 )
 
@@ -19,10 +20,10 @@ def test_split_merge():
 
 
 def test_split_into_one_and_merge():
-    """Test that split_text with into=1 returns the original text."""
+    """Test that split_text with into=1 round-trips correctly."""
     clear_text = "Hello World!"
     tokens = split_text(clear_text, into=1)
-    assert tokens == [b"Hello World!"]
+    assert len(tokens) == 1
     assert clear_text == merge_text(tokens)
 
 
@@ -81,3 +82,20 @@ def test_merge_text_requires_same_encoding():
 
     with pytest.raises(UnicodeDecodeError):
         merge_text(tokens, encoding="utf-8")
+
+
+def test_merge_bytes_into_rejects_tokens_from_different_splits():
+    """Test that merging tokens from different splits raises ValueError."""
+    token_a1, _token_a2 = split_bytes_into(b"Hello World!", 2)
+    _token_b1, token_b2 = split_bytes_into(b"Other Secret", 2)
+    with pytest.raises(ValueError, match="different splits"):
+        merge_bytes_into([token_a1, token_b2])
+
+
+def test_merge_io_rejects_tokens_from_different_splits():
+    """Test that merge_io raises ValueError for tokens from different splits."""  # noqa: E501
+    token_a1, _token_a2 = split_bytes_into(b"Hello World!", 2)
+    _token_b1, token_b2 = split_bytes_into(b"Other Secret", 2)
+    output = BytesIO()
+    with pytest.raises(ValueError, match="different splits"):
+        merge_io([BytesIO(token_a1), BytesIO(token_b2)], output)


### PR DESCRIPTION
## Problem

`merge_bytes_into` and `merge_io` silently accepted tokens produced by different `split_bytes_into` / `split_io` calls, returning corrupted data instead of raising an error. This made it impossible to detect accidental or malicious token mixing at the API boundary.

## Change

A 16-byte random **session ID** is now embedded at the start of every token produced by `split_bytes_into` and `split_io`.

New token format: `session_id (16 bytes) || XOR bytes`

`merge_bytes_into` and `merge_io` read the session ID from each input token/file and raise `ValueError` if they differ:

```
ValueError: tokens come from different splits: session IDs do not match
```

This converts a silent data corruption into a loud, actionable error.

## Internal helpers added

| Helper | Purpose |
|---|---|
| `_SESSION_ID_SIZE = 16` | Constant for the prefix length |
| `_split_bytes_raw` | Core XOR split without session ID (used by streaming `split_io`) |
| `_merge_bytes_raw` | Core XOR merge without session ID verification (used by streaming `merge_io`) |
| `_check_session_ids` | Raises `ValueError` when session IDs differ |

## Tests

- `test_merge_bytes_into_rejects_tokens_from_different_splits`: verifies that mixing tokens from two independent splits raises `ValueError`.
- `test_merge_io_rejects_tokens_from_different_splits`: same check via the file-IO interface.
- `test_split_into_one_and_merge`: relaxed from an exact-bytes assertion to a round-trip assertion, because the token now includes a random session ID prefix.

## Impact

- **Breaking change for callers who persist raw token bytes**: tokens produced before this change are not compatible with `merge_bytes_into` from this version (the first 16 bytes will be misinterpreted as a session ID).
- No public API renames; `split_bytes_into`, `merge_bytes_into`, `split_io`, `merge_io` signatures are unchanged.
