### PR TITLE
fix: validate token file sizes before merge to report truncated files

### DIFF
--- a/tally_token/__main__.py
+++ b/tally_token/__main__.py
@@ -8,27 +8,43 @@ from tally_token import merge_io, split_io
 
 
 def split_main(
-    *, source_path: str, dest_paths: list[str], bufsize: int = 1024,
+    *,
+    source_path: str,
+    dest_paths: list[str],
+    bufsize: int = 1024,
 ) -> None:
     # ensure closing all the files even if an exception is raised
     with ExitStack() as stack:
         infile = stack.enter_context(Path(source_path).open("rb"))
         outfiles = [
-            stack.enter_context(Path(path).open("wb"))
-            for path in dest_paths
+            stack.enter_context(Path(path).open("wb")) for path in dest_paths
         ]
         split_io(infile, list(outfiles), bufsize=bufsize)
 
 
+def _check_token_file_sizes(source_paths: list[str]) -> None:
+    sizes = [(p, Path(p).stat().st_size) for p in source_paths]
+    unique_sizes = {s for _, s in sizes}
+    if len(unique_sizes) > 1:
+        details = ", ".join(f"{p!r}: {s} bytes" for p, s in sizes)
+        raise ValueError(
+            "token files have mismatched sizes; they may be truncated or from "
+            f"different split operations ({details})",
+        )
+
+
 def merge_main(
-    *, dest_path: str, source_paths: list[str], bufsize: int = 1024,
+    *,
+    dest_path: str,
+    source_paths: list[str],
+    bufsize: int = 1024,
 ) -> None:
+    _check_token_file_sizes(source_paths)
     # ensure closing all the files even if an exception is raised
     with ExitStack() as stack:
         outfile = stack.enter_context(Path(dest_path).open("wb"))
         infiles = [
-            stack.enter_context(Path(path).open("rb"))
-            for path in source_paths
+            stack.enter_context(Path(path).open("rb")) for path in source_paths
         ]
         merge_io(infiles, outfile, bufsize=bufsize)
 
@@ -53,14 +69,20 @@ def main() -> None:
     split_parser.add_argument("src", help="The source file to be split.")
     split_parser.add_argument("dst", nargs="+", help="The destination files.")
     split_parser.add_argument(
-        "--bufsize", type=int, default=1024 * 2, help="The buffer size.",
+        "--bufsize",
+        type=int,
+        default=1024 * 2,
+        help="The buffer size.",
     )
 
     merge_parser = subparsers.add_parser("merge")
     merge_parser.add_argument("dst", help="The destination file.")
     merge_parser.add_argument("src", nargs="+", help="The source files.")
     merge_parser.add_argument(
-        "--bufsize", type=int, default=1024**2, help="The buffer size.",
+        "--bufsize",
+        type=int,
+        default=1024**2,
+        help="The buffer size.",
     )
 
     args = parser.parse_args()

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1,5 +1,7 @@
 import random
+import tempfile
 from io import BytesIO
+from pathlib import Path
 
 import pytest
 
@@ -8,6 +10,11 @@ from tally_token import (
     merge_io,
     merge_text,
     split_text,
+)
+from tally_token.__main__ import (
+    _check_token_file_sizes,
+    merge_main,
+    split_main,
 )
 
 
@@ -73,3 +80,33 @@ def test_encoding():
     clear_text = "こんにちは"
     tokens = split_text(clear_text, encoding="CP932")
     assert clear_text == merge_text(tokens, encoding="CP932")
+
+
+def test_merge_main_rejects_mismatched_file_sizes():
+    """Test that merge_main raises ValueError with file path info on size mismatch."""  # noqa: E501
+    with tempfile.TemporaryDirectory() as tmpdir:
+        p = Path(tmpdir)
+        src = p / "source.bin"
+        t1 = p / "token1.bin"
+        t2 = p / "token2.bin"
+        merged = p / "merged.bin"
+
+        src.write_bytes(b"Hello World!")
+        split_main(source_path=str(src), dest_paths=[str(t1), str(t2)])
+
+        # Truncate one token file to simulate partial write / download
+        original = t2.read_bytes()
+        t2.write_bytes(original[:-4])
+
+        with pytest.raises(ValueError, match="mismatched sizes"):
+            merge_main(dest_path=str(merged), source_paths=[str(t1), str(t2)])
+
+
+def test_check_token_file_sizes_passes_equal_sizes():
+    """Test that _check_token_file_sizes does not raise when all sizes match."""  # noqa: E501
+    with tempfile.TemporaryDirectory() as tmpdir:
+        p = Path(tmpdir)
+        for i in range(3):
+            (p / f"token{i}.bin").write_bytes(b"x" * 100)
+        paths = [str(p / f"token{i}.bin") for i in range(3)]
+        _check_token_file_sizes(paths)  # Should not raise


### PR DESCRIPTION
## Problem

When token files had different byte sizes (e.g., due to truncation or an incomplete download), `merge_main()` would propagate an opaque chunk-level error from inside `merge_io()`. The error message gave no indication of which files were involved or why the merge failed, making it difficult for users to diagnose the root cause.

## Fix

Added a `_check_token_file_sizes(source_paths)` helper that calls `stat()` on each source file before any file handle is opened. If the sizes differ, it raises a `ValueError` with a human-readable message that lists every file path along with its byte count:

```
ValueError: token files have mismatched sizes; they may be truncated or from
different split operations ('token1.bin': 512 bytes, 'token2.bin': 508 bytes)
```

`merge_main()` now calls this helper as its first step, before entering the `ExitStack` context.

## Changed Files

- `tally_token/__main__.py`: Added `_check_token_file_sizes()` and wired it into `merge_main()`.
- `tests/test_basis.py`: Added `test_merge_main_rejects_mismatched_file_sizes` (truncation scenario) and `test_check_token_file_sizes_passes_equal_sizes` (happy path).

## Trade-off: TOCTOU

The size check uses `stat()` before opening the files, so there is a narrow window where a file could theoretically be modified between the check and the actual read. This is a known TOCTOU (time-of-check/time-of-use) limitation. For a CLI tool operating on local files it is an acceptable trade-off: the check dramatically improves the diagnostic experience for the common case (truncated download, mismatched set of tokens) without adding meaningful complexity.
