### PR TITLE
fix: reduce default merge bufsize from 1MB to 2KB to limit peak memory

### DIFF
--- a/tally_token/__main__.py
+++ b/tally_token/__main__.py
@@ -8,27 +8,31 @@ from tally_token import merge_io, split_io
 
 
 def split_main(
-    *, source_path: str, dest_paths: list[str], bufsize: int = 1024,
+    *,
+    source_path: str,
+    dest_paths: list[str],
+    bufsize: int = 1024,
 ) -> None:
     # ensure closing all the files even if an exception is raised
     with ExitStack() as stack:
         infile = stack.enter_context(Path(source_path).open("rb"))
         outfiles = [
-            stack.enter_context(Path(path).open("wb"))
-            for path in dest_paths
+            stack.enter_context(Path(path).open("wb")) for path in dest_paths
         ]
         split_io(infile, list(outfiles), bufsize=bufsize)
 
 
 def merge_main(
-    *, dest_path: str, source_paths: list[str], bufsize: int = 1024,
+    *,
+    dest_path: str,
+    source_paths: list[str],
+    bufsize: int = 1024,
 ) -> None:
     # ensure closing all the files even if an exception is raised
     with ExitStack() as stack:
         outfile = stack.enter_context(Path(dest_path).open("wb"))
         infiles = [
-            stack.enter_context(Path(path).open("rb"))
-            for path in source_paths
+            stack.enter_context(Path(path).open("rb")) for path in source_paths
         ]
         merge_io(infiles, outfile, bufsize=bufsize)
 
@@ -53,14 +57,20 @@ def main() -> None:
     split_parser.add_argument("src", help="The source file to be split.")
     split_parser.add_argument("dst", nargs="+", help="The destination files.")
     split_parser.add_argument(
-        "--bufsize", type=int, default=1024 * 2, help="The buffer size.",
+        "--bufsize",
+        type=int,
+        default=1024 * 2,
+        help="The buffer size.",
     )
 
     merge_parser = subparsers.add_parser("merge")
     merge_parser.add_argument("dst", help="The destination file.")
     merge_parser.add_argument("src", nargs="+", help="The source files.")
     merge_parser.add_argument(
-        "--bufsize", type=int, default=1024**2, help="The buffer size.",
+        "--bufsize",
+        type=int,
+        default=1024 * 2,
+        help="The buffer size.",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Summary

The `merge` subcommand had a default `--bufsize` of 1 MB (`1024**2`) while
`split` used 2 KB (`1024 * 2`). With many token files, each merge iteration
allocated `n × 1 MB` of memory simultaneously — 1 GB for 1000 files at the
default.

This PR aligns the merge default to 2 KB, matching split. Peak memory for
a 1000-file merge drops from ~1 GB to ~2 MB at the default bufsize. Users
needing higher throughput can still pass `--bufsize`.

The `split_bytes_into` library function holds all `n` tokens in memory when
called directly with large input; that is inherent to the current API design
and is out of scope here.

## Changes

- `tally_token/__main__.py`: change merge `--bufsize` default from `1024**2` to `1024 * 2`

## Verification

All existing tests pass:

```
8 passed in 1.40s
```