### PR TITLE
fix: validate n and empty tokens to enforce split/merge invariants

### DIFF
--- a/tally_token/__init__.py
+++ b/tally_token/__init__.py
@@ -85,6 +85,9 @@ def split_bytes_into(source: bytes, into: int) -> list[bytes]:
         source: The bytes to be split.
         into: The number of tokens to be generated.
     """
+    if into <= 0:
+        msg = f"n must be a positive integer, got {into}"
+        raise ValueError(msg)
     tokens = []
     token = source
     for _ in range(into - 1):
@@ -101,12 +104,19 @@ def _merge1(token1: bytes, token2: bytes) -> bytes:
     return bytes(clear_text)
 
 
+def _validate_tokens_nonempty(tokens: list[bytes]) -> None:
+    if not tokens:
+        msg = "tokens must not be empty"
+        raise ValueError(msg)
+
+
 def merge_bytes_into(tokens: list[bytes]) -> bytes:
     """Merge tokens into a secret bytes.
 
     Args:
         tokens: The tokens to be merged.
     """
+    _validate_tokens_nonempty(tokens)
     token = tokens[0]
     for i in range(1, len(tokens)):
         if len(tokens[i]) != len(token):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -7,6 +7,7 @@ from tally_token import (
     merge_bytes_into,
     merge_io,
     merge_text,
+    split_bytes_into,
     split_text,
 )
 
@@ -81,3 +82,21 @@ def test_merge_text_requires_same_encoding():
 
     with pytest.raises(UnicodeDecodeError):
         merge_text(tokens, encoding="utf-8")
+
+
+def test_split_bytes_into_rejects_zero():
+    """Test that split_bytes_into raises ValueError for n=0."""
+    with pytest.raises(ValueError, match="n must be a positive integer"):
+        split_bytes_into(b"hello", 0)
+
+
+def test_split_bytes_into_rejects_negative():
+    """Test that split_bytes_into raises ValueError for negative n."""
+    with pytest.raises(ValueError, match="n must be a positive integer"):
+        split_bytes_into(b"hello", -1)
+
+
+def test_merge_bytes_into_rejects_empty():
+    """Test that merge_bytes_into raises ValueError for empty token list."""
+    with pytest.raises(ValueError, match="tokens must not be empty"):
+        merge_bytes_into([])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,11 @@ def test_cli():
     with tempfile.TemporaryDirectory() as tmpdir:
         subprocess.check_call(
             [
-                "dd", "if=/dev/urandom", "of=example.bin", "bs=1M", "count=10",
+                "dd",
+                "if=/dev/urandom",
+                "of=example.bin",
+                "bs=1M",
+                "count=10",
             ],
             cwd=tmpdir,
         )


### PR DESCRIPTION
## Summary

Two invariant violations in the split/merge API:

1. `split_bytes_into(source, n)` with `n <= 0` silently returned `[source]`
   (1 token) instead of the requested `n` tokens. Callers believing the
   return length equals `n` would store secret data in a way that gives
   no protection.

2. `merge_bytes_into([])` raised `IndexError` via `tokens[0]`, while the
   rest of the function raises `ValueError` for inconsistent inputs.
   Callers catching `ValueError` would not catch the empty-list case.

## Changes

- `tally_token/__init__.py`:
  - `split_bytes_into`: raise `ValueError` when `n <= 0`
  - `_validate_tokens_nonempty`: new private helper for the empty-list check
  - `merge_bytes_into`: call `_validate_tokens_nonempty` before accessing `tokens[0]`
- `tests/test_basis.py`: add three new tests covering `n=0`, `n=-1`, and empty token list

## Verification

```
11 passed in 1.50s
```