### PR TITLE
Enable uv dependency cache in CI workflows

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Enable caching and setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Enable caching and setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

`astral-sh/setup-uv` was used in both CI workflows without enabling its
built-in cache, causing uv to perform a cold-start package installation on
every run.

This PR adds `enable-cache: true` to the `setup-uv` step in
`python-test.yml` and `octocov.yml`, so the uv cache directory is preserved
across runs for the same dependency versions.

## Changes

- `.github/workflows/python-test.yml`: Add `enable-cache: true` to
  `astral-sh/setup-uv`.
- `.github/workflows/octocov.yml`: Add `enable-cache: true` to
  `astral-sh/setup-uv`.

## Verification

Lint and tests pass locally (`uv run poe check` and `uv run poe test`).
The cache effect can be observed by comparing CI run times before and after
merging this PR.

## Notes

`actions/setup-python` does not support uv as a built-in cache backend,
so the uv-native cache provided by `astral-sh/setup-uv` is the appropriate
mechanism here.
