### PR TITLE
fix: add CLI version flag

### DIFF
--- a/tally_token/__main__.py
+++ b/tally_token/__main__.py
@@ -4,7 +4,7 @@ import argparse
 from contextlib import ExitStack
 from pathlib import Path
 
-from tally_token import merge_io, split_io
+from tally_token import __version__, merge_io, split_io
 
 
 def split_main(
@@ -35,6 +35,11 @@ def merge_main(
 
 def main() -> None:
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"tally-token {__version__}",
+    )
     subparsers = parser.add_subparsers(
         required=True,
         dest="command",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,22 @@
 import subprocess
+import sys
 import tempfile
+
+from tally_token import __version__
+
+
+def test_cli_version():
+    """Test the CLI version output."""
+    result = subprocess.run(
+        [sys.executable, "-m", "tally_token", "--version"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == f"tally-token {__version__}\n"
+    assert result.stderr == ""
 
 
 def test_cli():


### PR DESCRIPTION
## Summary
- add a top-level `--version` flag to the CLI
- cover `python -m tally_token --version` with a regression test

## Verification
- `uv run python -m tally_token --version`
- `git diff --check`
- `uv sync`
- `uv run poe check`
- `uv run ruff check .`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
