### PR TITLE
fix: promote Development Status to Beta and document token format version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     {name = "Yui KITSU", email = "kitsuyui+github@kitsuyui.com"}
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "License :: OSI Approved :: BSD License",
     "Topic :: Security :: Cryptography",
     "Programming Language :: Python :: 3.10",

--- a/tally_token/__init__.py
+++ b/tally_token/__init__.py
@@ -15,6 +15,12 @@ from ._version import __version__
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
+# Token format version for split_bytes_into / merge_bytes_into.
+# Version 0: raw XOR pads, no header. Tokens are same length as source.
+# Bump this and add a version-byte prefix if the algorithm ever changes
+# so that old and new tokens can be distinguished at merge time.
+SPLIT_TOKEN_FORMAT_VERSION = 0
+
 
 def split_text(
     clear_text: str,
@@ -159,6 +165,7 @@ def _generate_random_token(size: int) -> bytes:
 
 
 __all__ = [
+    "SPLIT_TOKEN_FORMAT_VERSION",
     "__version__",
     "merge_bytes_into",
     "merge_io",


### PR DESCRIPTION
## Summary

Two versioning-related improvements:

**Development Status classifier**: The package is at v0.6.3 with several stable minor releases. The `Development Status :: 3 - Alpha` PyPI classifier no longer reflects the maturity level and may cause enterprise dependency policies to reject the package. Bumped to `Development Status :: 4 - Beta`.

**Token format version constant**: The current `split_bytes_into` / `merge_bytes_into` algorithm produces raw XOR pads with no header bytes. If the algorithm is replaced in a future version (e.g. adding authentication), there is no version marker to distinguish old tokens from new ones. `SPLIT_TOKEN_FORMAT_VERSION = 0` makes this explicit: the current format is "version 0, headerless". Future algorithm changes should bump this constant and introduce a version-byte prefix.

## Changes

- `pyproject.toml`: `Development Status :: 3 - Alpha` → `Development Status :: 4 - Beta`
- `tally_token/__init__.py`: add `SPLIT_TOKEN_FORMAT_VERSION = 0` with a docstring-style comment; add to `__all__`

## Trade-offs

- Bumping from Alpha to Beta signals greater stability to package consumers. Callers relying on the PyPI classifier to filter out "unstable" packages will now see this package as a candidate.
- `SPLIT_TOKEN_FORMAT_VERSION` is a new public constant. It does not change the token format; it only names the current state. Any code that reads this value and branches on it should be aware that version 0 means "no header, raw XOR pads."
