### PR TITLE
feat: establish logging policy and add CLI error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,20 @@ This is useful for split binary data.
 b'Hello, World!'
 ```
 
+# Security and Logging
+
+This library handles secret material (token bytes) and follows a
+**log-nothing policy**: no secret data should appear in log output.
+
+- The library installs a `NullHandler` on its root logger so log records
+  are silently discarded unless the *application* configures a handler.
+  This is the [standard practice for libraries](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library).
+- **Do not log token bytes or plain-text secrets** in your application code.
+  Functions such as `split_bytes_into`, `_split1`, `write_split_tokens`, and
+  `merge_bytes_into` operate directly on secret material.
+- If you add debug logging to code that calls this library, ensure no
+  token content is captured in log records or exception messages.
+
 # Reference
 
 - Tally stick https://en.wikipedia.org/wiki/Tally_stick

--- a/tally_token/__init__.py
+++ b/tally_token/__init__.py
@@ -6,11 +6,14 @@ The secret can be recovered only if all the tokens are merged together.
 
 from __future__ import annotations
 
+import logging
 import secrets
 from io import BufferedReader, BufferedWriter
 
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
 from ._version import __version__
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
 def split_text(

--- a/tally_token/__main__.py
+++ b/tally_token/__main__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from contextlib import ExitStack
 from pathlib import Path
 
@@ -8,27 +9,31 @@ from tally_token import merge_io, split_io
 
 
 def split_main(
-    *, source_path: str, dest_paths: list[str], bufsize: int = 1024,
+    *,
+    source_path: str,
+    dest_paths: list[str],
+    bufsize: int = 1024,
 ) -> None:
     # ensure closing all the files even if an exception is raised
     with ExitStack() as stack:
         infile = stack.enter_context(Path(source_path).open("rb"))
         outfiles = [
-            stack.enter_context(Path(path).open("wb"))
-            for path in dest_paths
+            stack.enter_context(Path(path).open("wb")) for path in dest_paths
         ]
         split_io(infile, list(outfiles), bufsize=bufsize)
 
 
 def merge_main(
-    *, dest_path: str, source_paths: list[str], bufsize: int = 1024,
+    *,
+    dest_path: str,
+    source_paths: list[str],
+    bufsize: int = 1024,
 ) -> None:
     # ensure closing all the files even if an exception is raised
     with ExitStack() as stack:
         outfile = stack.enter_context(Path(dest_path).open("wb"))
         infiles = [
-            stack.enter_context(Path(path).open("rb"))
-            for path in source_paths
+            stack.enter_context(Path(path).open("rb")) for path in source_paths
         ]
         merge_io(infiles, outfile, bufsize=bufsize)
 
@@ -53,14 +58,20 @@ def main() -> None:
     split_parser.add_argument("src", help="The source file to be split.")
     split_parser.add_argument("dst", nargs="+", help="The destination files.")
     split_parser.add_argument(
-        "--bufsize", type=int, default=1024 * 2, help="The buffer size.",
+        "--bufsize",
+        type=int,
+        default=1024 * 2,
+        help="The buffer size.",
     )
 
     merge_parser = subparsers.add_parser("merge")
     merge_parser.add_argument("dst", help="The destination file.")
     merge_parser.add_argument("src", nargs="+", help="The source files.")
     merge_parser.add_argument(
-        "--bufsize", type=int, default=1024**2, help="The buffer size.",
+        "--bufsize",
+        type=int,
+        default=1024**2,
+        help="The buffer size.",
     )
 
     args = parser.parse_args()
@@ -70,5 +81,13 @@ def main() -> None:
         merge_main(dest_path=args.dst, source_paths=args.src)
 
 
+def _cli_entry() -> None:
+    try:
+        main()
+    except (OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from None
+
+
 if __name__ == "__main__":
-    main()
+    _cli_entry()


### PR DESCRIPTION
## Summary

This library handles secret material (token bytes) but had no logging infrastructure or documented logging policy. It also surfaced raw Python tracebacks to CLI users on errors.

Three changes:

1. **Library: NullHandler** — `tally_token/__init__.py` installs `logging.NullHandler()` on the package root logger, which is the [standard practice for libraries](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library). This means the library's log records are silently discarded unless the *application* explicitly configures a handler — preventing accidental noise and giving application authors full control.

2. **CLI: clean error messages** — `tally_token/__main__.py` adds `_cli_entry()`, which wraps `main()` and catches `OSError` / `ValueError` to print `error: <message>` to stderr and exit with code 1, instead of showing internal file paths and stack frames.

3. **README: logging policy** — New "Security and Logging" section documents that token bytes must not appear in log output and explains the NullHandler role.

## Changes

- `tally_token/__init__.py`: `import logging` + NullHandler setup
- `tally_token/__main__.py`: `import sys` + `_cli_entry()` wrapper
- `README.md`: "Security and Logging" section

## Validation

- `ruff format` + `ruff check`: pass
- `mypy --strict`: pass
- `vulture`: 0 findings
- All 8 tests pass

## Trade-offs

- NullHandler is silent and does not change observable behaviour. Application authors who want logs from this library must add a handler explicitly (standard pattern).
- `_cli_entry()` only catches `OSError` and `ValueError` — unexpected errors still produce tracebacks (appropriate; only well-known failure modes are caught).
