### PR TITLE
Document text token encoding contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ You can use `merge_text` to merge tokens into text. `merge_text` returns clearte
 'こんにちは'
 ```
 
+The returned tokens are opaque bytes and do not store the encoding name. When
+splitting text with a custom encoding, keep that encoding out of band and pass
+the same value to `merge_text`; using a different encoding can raise
+`UnicodeDecodeError` or return mojibake if the bytes happen to decode.
+
 ### bytes interface
 
 You can use `split_bytes_into` and `merge_bytes_into` to split and merge bytes.

--- a/tally_token/__init__.py
+++ b/tally_token/__init__.py
@@ -24,7 +24,9 @@ def split_text(
     Args:
         clear_text: The text to be split.
         into: The number of tokens to be generated.
-        encoding: The encoding of the text.
+        encoding: The encoding used to convert text to bytes. Tokens do
+            not store this value; pass the same encoding to merge_text to
+            recover the original text.
     """
     clear_text_bytes = bytes(clear_text, encoding=encoding)
     return split_bytes_into(clear_text_bytes, into)
@@ -119,7 +121,9 @@ def merge_text(tokens: list[bytes], *, encoding: str = "utf-8") -> str:
 
     Args:
         tokens: The tokens to be merged.
-        encoding: The encoding of the text.
+        encoding: The encoding used to decode the merged bytes. It must
+            match the encoding passed to split_text because tokens do not
+            carry encoding metadata.
     """
     clear_text_bytes = merge_bytes_into(tokens)
     return clear_text_bytes.decode(encoding)

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -73,3 +73,11 @@ def test_encoding():
     clear_text = "こんにちは"
     tokens = split_text(clear_text, encoding="CP932")
     assert clear_text == merge_text(tokens, encoding="CP932")
+
+
+def test_merge_text_requires_same_encoding():
+    """Test that text tokens require the original encoding."""
+    tokens = split_text("こんにちは", encoding="CP932")
+
+    with pytest.raises(UnicodeDecodeError):
+        merge_text(tokens, encoding="utf-8")


### PR DESCRIPTION
## Summary
- document that `split_text` returns opaque byte tokens that do not store the text encoding
- clarify that `merge_text` must use the same encoding that was used to split text tokens
- add a regression test for decoding CP932 text tokens with the wrong encoding

## Verification
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
- `uvx vulture tally_token tests --min-confidence 100`
