### PR TITLE
ci: add self-hosted Renovate workflow

### DIFF
--- a/.github/workflows/private-renovate.yml
+++ b/.github/workflows/private-renovate.yml
@@ -1,0 +1,15 @@
+name: Private Renovate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 20 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/private-renovate.yml@716161c37741888ae80a615b6f2f6d5d2ba01a67 # main
+    secrets:
+      RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
## Summary

Add `.github/workflows/private-renovate.yml` — a self-hosted Renovate workflow that restores automated dependency updates.

## Background

The Renovate GitHub App stopped creating dependency update PRs since 2026-04-14. This self-hosted workflow replaces that integration to resume automated updates.

## Changes

- Added `.github/workflows/private-renovate.yml`
  - Runs daily at 20:00 UTC via `schedule` (`cron: "0 20 * * *"`)
  - Also supports manual trigger via `workflow_dispatch`
  - Delegates to the shared reusable workflow at `kitsuyui/gh-actions-workflows` (pinned to a 40-character commit SHA)

## Operational Requirement

Before this workflow runs successfully, the `RENOVATE_TOKEN` secret must be set in the repository settings (Settings → Secrets and variables → Actions).
