### PR TITLE
Add changelog entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Versions are generated from Git tags with setuptools-scm. Release artifacts
+and historical release metadata are available from
+[GitHub Releases](https://github.com/kitsuyui/python-tally-token/releases).
+
+## Unreleased
+
+### Added
+
+- Added this changelog and linked it from the README and package metadata.
+
+## Release History
+
+Earlier releases were published before this changelog was added. Use the
+linked GitHub releases for historical artifacts and tag metadata.
+
+- [v0.6.3](https://github.com/kitsuyui/python-tally-token/releases/tag/v0.6.3) - 2026-02-24
+- [v0.6.2](https://github.com/kitsuyui/python-tally-token/releases/tag/v0.6.2) - 2025-01-31
+- [v0.6.1](https://github.com/kitsuyui/python-tally-token/releases/tag/v0.6.1) - 2025-01-31
+- [v0.6.0](https://github.com/kitsuyui/python-tally-token/releases/tag/v0.6.0) - 2024-10-15
+- [v0.5.0](https://github.com/kitsuyui/python-tally-token/releases/tag/v0.5.0) - 2023-10-06
+- [v0.4.0](https://github.com/kitsuyui/python-tally-token/releases/tag/v0.4.0) - 2023-09-06
+- [v0.3.1](https://github.com/kitsuyui/python-tally-token/releases/tag/v0.3.1) - 2023-07-25
+- [v0.3.0](https://github.com/kitsuyui/python-tally-token/releases/tag/v0.3.0) - 2023-07-15
+- [v0.2.0](https://github.com/kitsuyui/python-tally-token/releases/tag/v0.2.0) - 2023-07-15
+- [v0.1.0](https://github.com/kitsuyui/python-tally-token/releases/tag/v0.1.0) - 2023-07-15

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ tally-token is a Python library for split data into tokens with same length.
 <a href="https://en.wikipedia.org/wiki/Tally_stick#/media/File:Medieval_tally_sticks.jpg" target="_blank"><img src="https://github.com/kitsuyui/python-tally-token/assets/2596972/103a0184-c508-4ce6-9ed3-1b1eb58bc6cc" style="width:20rem" /></a>
 > Medieval English split tally stick (front and reverse view). The stick is notched and inscribed to record a debt owed to the rural dean of Preston Candover, Hampshire, of a tithe of 20d each on 32 sheep, amounting to a total sum of £2 13s. 4d.
 
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for release notes and upgrade notes.
+
 # Usage
 
 ## Install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ tally-token = "tally_token.__main__:main"
 
 [project.urls]
 Homepage = "https://github.com/kitsuyui/python-tally-token"
+Changelog = "https://github.com/kitsuyui/python-tally-token/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Summary:
- Add `CHANGELOG.md` as the release-notes entry point.
- Link the changelog from the README and package metadata.
- Point historical release entries to existing GitHub release tags.

Verification:
- `uv sync`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
- `uvx typos README.md CHANGELOG.md pyproject.toml`
- `git diff --check`

Note: `uv build` passed with pre-existing setuptools license deprecation warnings.