### PR TITLE
ci: add octocov metric thresholds

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,10 +1,14 @@
 # https://github.com/k1LoW/octocov?tab=readme-ov-file#configuration
 coverage:
+  acceptable: current >= 70%
   paths:
     - coverage.xml
 codeToTestRatio:
+  acceptable: 1:0.5
   code:
     - "**/*.py"
+    - "!.venv/**/*.py"
+    - "!tests/**/*.py"
   test:
     - "tests/**/*.py"
 testExecutionTime:


### PR DESCRIPTION
## Summary

- Add octocov acceptable thresholds for coverage and code-to-test ratio.
- Exclude `.venv` and `tests` from the code-to-test ratio code glob so CI-created virtualenv files and tests are not counted as production code.

## Verification

- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `git diff --check`
- local octocov config evaluation: Coverage 73.6%, Code to Test Ratio 1:0.5
