### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,34 @@ This library handles secret material (token bytes) and follows a
 - 割符 https://ja.wikipedia.org/wiki/%E5%89%B2%E7%AC%A6
 - One-time pad https://en.wikipedia.org/wiki/One-time_pad
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install dependencies
+uv sync
+
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `uv run poe check`
+- **pre-push**: `uv run poe check` and `uv run poe test`
+
+You can also run the checks manually:
+
+```sh
+uv run poe check
+uv run poe test
+```
+
+CI still runs the full matrix (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
+
 # LICENSE
 
 BSD 3-Clause License

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+
+pre-push:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` so the same checks CI runs (`poe check`, `poe test`) also run locally on pre-commit and pre-push.
- CI workflows are **not changed** — GitHub Actions continues to run the full matrix; hooks only surface failures earlier on a developer's machine.

## Changes

- **`lefthook.yml`** (new): configures two hook stages.
  - `pre-commit`: runs `uv run poe check` (ruff + mypy).
  - `pre-push`: runs `uv run poe check` and `uv run poe test`.
  - Each job unsets `GIT_*` environment variables before running so nested repositories are not affected.
- **`README.md`**: adds a `## Development` section (inserted before `# LICENSE`) describing how to install lefthook and what the hooks do.

## Verification

- `uv run poe check` passes on current code (ruff + mypy clean).
- `uv run poe test` passes on current code (17/17 tests pass).
- The pre-commit hook fired and passed during the commit that introduced these files.
- The pre-push hook fired and passed (check + test) when pushing this branch.

## Notes

- Requires `lefthook` on the developer's `PATH` (`lefthook install` is a one-time step).
- No CI workflow was added, removed, or modified.
