### PR TITLE
docs: add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Report a reproducible problem in tally-token
+title: "bug: "
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+Describe the problem.
+
+## Reproduction
+
+Steps to reproduce:
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What did you expect to happen?
+
+## Actual Behavior
+
+What happened instead?
+
+## Environment
+
+- `tally-token` version:
+- Python version:
+- Operating system:
+- Installation method:
+
+## Additional Context
+
+Do not include token bytes, plain-text secrets, or private files. If this is a
+security issue, do not submit it here; use the private reporting process in
+`SECURITY.md`.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an improvement for tally-token
+title: "feat: "
+labels: enhancement
+assignees: ""
+---
+
+## Summary
+
+Describe the requested change.
+
+## Motivation
+
+What problem would this solve?
+
+## Proposed Behavior
+
+Describe the behavior you want.
+
+## Alternatives Considered
+
+Describe any workaround or alternate design you considered.
+
+## Additional Context
+
+Do not include token bytes, plain-text secrets, or private files.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+- Describe the change.
+
+## Verification
+
+- [ ] `uv run poe check`
+- [ ] `uv run poe test`
+- [ ] `uv run poe coverage-xml`
+- [ ] `uv build`
+
+## Security Notes
+
+- [ ] This change does not log, expose, or commit token bytes or plain-text
+      secrets.
+- [ ] Security-sensitive behavior changes are explained above.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# Code of Conduct
+
+## Our Standards
+
+Project discussions should be respectful, constructive, and focused on the
+work. Be considerate of different experience levels and communication styles.
+
+Examples of welcome behavior:
+
+- using clear and respectful language;
+- giving actionable feedback;
+- assuming good intent while asking for clarification;
+- keeping security-sensitive details out of public discussions.
+
+Examples of unacceptable behavior:
+
+- harassment, threats, or discriminatory language;
+- publishing private information without permission;
+- repeated off-topic or disruptive comments;
+- public disclosure of unpatched security vulnerabilities.
+
+## Enforcement
+
+Maintainers may edit, hide, or remove comments and may limit participation when
+behavior is harmful to the project or its contributors.
+
+For security vulnerabilities, use the private reporting process in
+`SECURITY.md` instead of public discussion.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing
+
+Thank you for improving `tally-token`.
+
+## Development Setup
+
+This project uses [uv](https://docs.astral.sh/uv/) for dependency management
+and [Poe the Poet](https://poethepoet.natn.io/) for common tasks.
+
+```sh
+uv sync
+```
+
+## Local Checks
+
+Run the formatter before opening a pull request:
+
+```sh
+uv run poe format
+```
+
+Run lint and type checks:
+
+```sh
+uv run poe check
+```
+
+Run the test suite:
+
+```sh
+uv run poe test
+```
+
+Run the coverage job used by CI:
+
+```sh
+uv run poe coverage-xml
+```
+
+Check that the package builds:
+
+```sh
+uv build
+```
+
+## Pull Requests
+
+Before opening a pull request, make sure that:
+
+- the change is focused on one topic;
+- relevant checks pass locally;
+- tests or documentation are updated when behavior changes;
+- no token bytes, plain-text secrets, or other sensitive data are logged or
+  included in fixtures.
+
+When reporting a failing check, include the command you ran and the relevant
+error output.
+
+## Security Changes
+
+This library can operate on secret material. If your change affects token
+generation, merging, file output, logging, or error messages, explain the
+security impact in the pull request.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not open a public GitHub Issue for security vulnerabilities.
+
+Use GitHub private vulnerability reporting:
+
+<https://github.com/kitsuyui/python-tally-token/security/advisories/new>
+
+Include the following details when possible:
+
+- affected version or commit;
+- a short impact summary;
+- steps to reproduce or a minimal proof of concept;
+- whether token bytes, plain-text secrets, or generated files can be exposed or corrupted.
+
+The maintainer will review the report as soon as possible. If the issue is
+confirmed, a fix and public advisory will be prepared after coordinated
+disclosure is appropriate.


### PR DESCRIPTION
## Summary
- Add SECURITY.md with private vulnerability reporting guidance for this package.
- Add CONTRIBUTING.md, a code of conduct, issue templates, and a pull request template.
- Include reminders to avoid sharing token bytes, plain-text secrets, or security-sensitive details in public reports.

## Verification
- uv sync
- uv run poe check
- uv run poe test
- uv run poe coverage-xml
- uv build
- git diff --check
- typos SECURITY.md CONTRIBUTING.md CODE_OF_CONDUCT.md .github/ISSUE_TEMPLATE/bug_report.md .github/ISSUE_TEMPLATE/feature_request.md .github/PULL_REQUEST_TEMPLATE.md

## Notes
- `uv build` passes with existing setuptools license deprecation warnings.
- The reusable spellcheck workflow and release publishing secrets are not fully reproducible locally.
