### PR TITLE
ci: migrate PyPI publish to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -41,13 +42,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

Migrates the PyPI publish workflow from legacy API token authentication to OIDC Trusted Publishing.

### What changed

- Added `id-token: write` permission to the `deploy` job
- Removed `user: __token__` and `password: ${{ secrets.TEST_PYPI_API_TOKEN }}` from the Test PyPI publish step
- Removed `user: __token__` and `password: ${{ secrets.PYPI_API_TOKEN }}` from the PyPI publish step

### Why

Long-lived API tokens stored as repository secrets are a persistent credential that must be rotated and can be leaked. OIDC Trusted Publishing removes this risk: GitHub Actions mints a short-lived OIDC token at publish time, and PyPI verifies the repository and workflow identity directly. No long-lived secret is stored or transmitted. This is the [current PyPA recommendation](https://docs.pypi.org/trusted-publishers/).

## Prerequisite before merging

A maintainer must configure a Trusted Publisher on both PyPI and TestPyPI for this project before this workflow will succeed on release:

- **Repository:** `kitsuyui/python-tally-token`
- **Workflow file:** `.github/workflows/pypi-publish.yml`

Steps: PyPI project Settings → Publishing → Add a new publisher → GitHub Actions, then fill in the repository and workflow name. Repeat for TestPyPI.

Until Trusted Publishing is configured, publish jobs on release events will fail. Pull request builds (which skip the publish steps) are unaffected.
