### PR TITLE
fix: enforce strict=True in _write_split_tokens_raw zip

### DIFF
--- a/tally_token/__init__.py
+++ b/tally_token/__init__.py
@@ -72,7 +72,7 @@ def _write_split_tokens_raw(
     output_sizes: int,
 ) -> None:
     token_bytes = _split_bytes_raw(source, output_sizes)
-    for token, outfile in zip(token_bytes, outfiles, strict=False):
+    for token, outfile in zip(token_bytes, outfiles, strict=True):
         outfile.write(token)
 
 


### PR DESCRIPTION
## Summary

Change `strict=False` to `strict=True` in the `zip()` call inside `_write_split_tokens_raw`.

`_split_bytes_raw(source, output_sizes)` always returns exactly `output_sizes` tokens, and `output_sizes` is always `len(outfiles)` (set in `split_io`). The two iterables therefore always have equal length. Using `strict=False` suppresses the length-mismatch check that Python's `zip` can perform, silently dropping tokens if the invariant is ever violated.

Changing to `strict=True` makes the existing invariant explicit: any future refactoring that breaks the length equality is caught immediately at runtime with a `ValueError` rather than silently producing an incomplete (and unrecoverable) token file set.

## Changes

- `tally_token/__init__.py`: `zip(..., strict=False)` → `zip(..., strict=True)` in `_write_split_tokens_raw`

## Verification

All 17 existing tests pass (`poe test`). The change has no functional effect on the current code path; it only makes the length-equality contract explicit.

```
17 passed in 1.65s
```
