### PR TITLE
chore: remove stale .flake8 config superseded by ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 120


### PR DESCRIPTION
## Summary

Remove `.flake8`, a configuration file that is no longer used by any CI workflow or local tooling command.

The project migrated to `ruff` as its linter. `ruff`'s line-length is configured to `79` in `pyproject.toml`. The leftover `.flake8` still set `max-line-length = 120`, leaving two contradictory line-length values in the repository with no way to tell which one is canonical.

Neither `poe check` (`ruff check` + `mypy`) nor the CI workflow `python-test.yml` calls `flake8`, so `.flake8` has no effect on any automated check. Its only effect is to confuse editors with `flake8` plugins or contributors who read it as the active style guide.

## Changes

- `.flake8`: deleted (contained `[flake8] max-line-length = 120`, conflicting with `pyproject.toml`'s `line-length = 79`)

## Verification

- `ruff check tally_token` — All checks passed
- `ruff format --check tally_token` — 2 files already formatted
- No changes to `pyproject.toml`, `poe check`, or CI workflows; lint toolchain is unchanged

## Trade-offs

Deleting `.flake8` without adding a replacement section in `pyproject.toml` is sufficient because `ruff` is already the sole active linter and its configuration lives entirely in `pyproject.toml`. Adding a `[tool.flake8]` tombstone entry would require installing or enabling a `flake8` integration that is not otherwise needed.
