### PR TITLE
fix: reject tokens shorter than the session ID during merge

### DIFF
--- a/tally_token/__init__.py
+++ b/tally_token/__init__.py
@@ -157,6 +157,16 @@ def _check_session_ids(session_ids: list[bytes]) -> None:
         )
 
 
+def _check_token_minimum_lengths(tokens: list[bytes]) -> None:
+    for i, token in enumerate(tokens):
+        if len(token) < _SESSION_ID_SIZE:
+            msg = (
+                "token at index "
+                f"{i} is shorter than the {_SESSION_ID_SIZE}-byte session ID"
+            )
+            raise ValueError(msg)
+
+
 def merge_bytes_into(tokens: list[bytes]) -> bytes:
     """Merge tokens into a secret bytes.
 
@@ -167,6 +177,8 @@ def merge_bytes_into(tokens: list[bytes]) -> bytes:
     Args:
         tokens: The tokens to be merged.
     """
+    _validate_tokens_nonempty(tokens)
+    _check_token_minimum_lengths(tokens)
     session_ids = [t[:_SESSION_ID_SIZE] for t in tokens]
     _check_session_ids(session_ids)
     stripped = [t[_SESSION_ID_SIZE:] for t in tokens]
@@ -199,6 +211,7 @@ def merge_io(
         outfile: The file to be written.
     """
     session_ids = [f.read(_SESSION_ID_SIZE) for f in infiles]
+    _check_token_minimum_lengths(session_ids)
     _check_session_ids(session_ids)
     while True:
         chunks = [f.read(bufsize) for f in infiles]

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -76,6 +76,26 @@ def test_merge_io_rejects_mismatched_token_lengths():
         merge_io([BytesIO(token1), BytesIO(token2[:-1])], output)
 
 
+def test_merge_bytes_into_rejects_equally_short_tokens():
+    """Test that merge_bytes_into rejects tokens shorter than the session ID."""
+    with pytest.raises(
+        ValueError,
+        match="token at index 0 is shorter than the 16-byte session ID",
+    ):
+        merge_bytes_into([b"A" * 15, b"A" * 15])
+
+
+def test_merge_io_rejects_equally_short_tokens():
+    """Test that merge_io rejects token files shorter than the session ID."""
+    output = BytesIO()
+
+    with pytest.raises(
+        ValueError,
+        match="token at index 0 is shorter than the 16-byte session ID",
+    ):
+        merge_io([BytesIO(b"A" * 15), BytesIO(b"A" * 15)], output)
+
+
 def test_encoding():
     """Test that split_text and merge_text accept custom encoding."""
     clear_text = "こんにちは"


### PR DESCRIPTION
## Summary
- reject token inputs that are shorter than the 16-byte session ID before merge strips the header
- apply the same validation to `merge_bytes_into` and `merge_io` so uniformly truncated inputs fail fast
- add regression tests for equally short in-memory tokens and token streams

## Verification
- `uv run poe check`
- `uv run poe test`
