### PR TITLE
fix: skip private renovate when token is unavailable

### DIFF
--- a/.github/workflows/private-renovate.yml
+++ b/.github/workflows/private-renovate.yml
@@ -9,7 +9,26 @@ permissions:
   contents: read
 
 jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      has_renovate_token: ${{ steps.check.outputs.has_renovate_token }}
+    steps:
+      - name: Check Renovate token availability
+        id: check
+        env:
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+        run: |
+          if [ -n "${RENOVATE_TOKEN:-}" ]; then
+            echo "has_renovate_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_renovate_token=false" >> "$GITHUB_OUTPUT"
+            echo "RENOVATE_TOKEN is not configured; skipping Private Renovate run."
+          fi
+
   renovate:
+    needs: preflight
+    if: needs.preflight.outputs.has_renovate_token == 'true'
     uses: kitsuyui/gh-actions-workflows/.github/workflows/private-renovate.yml@716161c37741888ae80a615b6f2f6d5d2ba01a67 # main
     secrets:
       RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
## Summary

- add a preflight job that detects whether `RENOVATE_TOKEN` is configured
- skip the reusable Private Renovate job when the token is unavailable instead of failing immediately

## Why

The reusable workflow requires `RENOVATE_TOKEN`, but this repository does not always provide it for scheduled runs. Gating the call in the caller workflow keeps the workflow green when the secret is absent while preserving the existing Renovate path for repositories that do provide the token.

## Verification

- `uv run poe check`
- `uv run poe test`
- `uv run python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path(\".github/workflows/private-renovate.yml\").read_text()); print(\"yaml-ok\")"`
