### PR TITLE
fix: reject duplicate split destinations before writing tokens

### DIFF
--- a/tally_token/__main__.py
+++ b/tally_token/__main__.py
@@ -34,6 +34,14 @@ def _rename_temps(tmp_paths: list[Path], dest_paths: list[Path]) -> None:
         tmp_path.replace(dest)
 
 
+def _check_duplicate_dest_paths(dest_paths: list[Path]) -> None:
+    if len(dest_paths) != len(set(dest_paths)):
+        raise ValueError(
+            "destination paths must be unique "
+            "to avoid overwriting split tokens",
+        )
+
+
 def split_main(
     *,
     source_path: str,
@@ -41,6 +49,7 @@ def split_main(
     bufsize: int = 1024,
 ) -> None:
     dest_path_objects = [Path(p) for p in dest_paths]
+    _check_duplicate_dest_paths(dest_path_objects)
     tmp_paths: list[Path] = []
     try:
         with ExitStack() as stack:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 import tempfile
+from pathlib import Path
 
 from tally_token import __version__
 
@@ -72,3 +73,33 @@ def test_cli():
                 f"{tmpdir}/example-merged.bin",
             ],
         )
+
+
+def test_cli_split_rejects_duplicate_destinations():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source_path = Path(tmpdir) / "example.bin"
+        source_path.write_bytes(b"secret")
+        duplicate_dest = Path(tmpdir) / "example.bin.1"
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tally_token",
+                "split",
+                str(source_path),
+                str(duplicate_dest),
+                str(duplicate_dest),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 1
+        assert result.stdout == ""
+        assert (
+            "destination paths must be unique to avoid overwriting split tokens"
+            in result.stderr
+        )
+        assert not duplicate_dest.exists()


### PR DESCRIPTION
## Summary
- reject duplicate destination paths before `split` starts writing temporary token files
- add a CLI regression test that covers repeated destination arguments

## Testing
- `uv run poe check`
- `uv run poe test`
